### PR TITLE
doc: 開発ルールをorgのトップページに追加

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,3 +5,6 @@
 
 ## ガントチャート
 https://github.com/orgs/GameCreate-LiverPate/projects/1
+
+## 開発ルール
+https://github.com/GameCreate-LiverPate/development-rules


### PR DESCRIPTION
https://github.com/GameCreate-LiverPate に開発ルールのリンクが表示されるようにする